### PR TITLE
Replaces tomato emoji with GitHub flavored markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🍅 Plost
+# :tomato: Plost
 
 A deceptively simple plotting library for [Streamlit](https://github.com/streamlit/streamlit).
 


### PR DESCRIPTION
The tomato emoji in the README breaks installation on Windows via setup.py:

```python
with open("README.md", "r") as fh:
    long_description = fh.read()
```

Replaces the emoji with [GitHub flavored markdown](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#using-emoji) `:tomato:` so that the emoji is correctly rendered on GitHub +  the README is parsed on Windows.